### PR TITLE
Refactor: Consolidate media to pics/ and update paths.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -61,7 +61,7 @@
     function draw() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       const bg = new Image();
-      bg.src = "images/background.png";
+      bg.src = "pics/background.png";
       bg.onload = () => ctx.drawImage(bg, 0, 0, canvas.width, canvas.height);
     }
 
@@ -75,17 +75,17 @@
 
     // --- HAND IMAGE OPTIONS ---
 const handOptions = [
-  { home: "images/Human.png", about: "images/Human-white.png" },
-  { home: "images/Alien.png", about: "images/Alien-white.png" },
-  { home: "images/Bones.png", about: "images/Bones-white.png" },
-  { home: "images/Cyberpunk.png", about: "images/Cyberpunk-white.png" },
-  { home: "images/Grandma.png", about: "images/Grandma-white.png" },
-  { home: "images/Robot.png", about: "images/Robot-white.png" },
-  { home: "images/Mockup.png", about: "images/Mockup-white.png" },
-  { home: "images/Pixel.png", about: "images/Pixel-white.png" },
-  { home: "images/Manga.png", about: "images/Manga-white.png" },
-  { home: "images/Illustration.png", about: "images/Illustration-white.png" },
-  { home: "images/Clay.png", about: "images/Clay-white.png" }
+  { home: "pics/Human.png", about: "pics/Human-white.png" },
+  { home: "pics/Alien.png", about: "pics/Alien-white.png" },
+  { home: "pics/Bones.png", about: "pics/Bones-white.png" },
+  { home: "pics/Cyberpunk.png", about: "pics/Cyberpunk-white.png" },
+  { home: "pics/Grandma.png", about: "pics/Grandma-white.png" },
+  { home: "pics/Robot.png", about: "pics/Robot-white.png" },
+  { home: "pics/Mockup.png", about: "pics/Mockup-white.png" },
+  { home: "pics/Pixel.png", about: "pics/Pixel-white.png" },
+  { home: "pics/Manga.png", about: "pics/Manga-white.png" },
+  { home: "pics/Illustration.png", about: "pics/Illustration-white.png" },
+  { home: "pics/Clay.png", about: "pics/Clay-white.png" }
 ];
 const nonMockupOptions = handOptions.filter(h => !h.home.includes("Mockup"));
 

--- a/wp-site.html
+++ b/wp-site.html
@@ -29,7 +29,7 @@
   <div id="homeContent" class="screenContent">
     <div>
       <div class="headerTop">
-        <a href=""><img src="images/smfidalgo_logo.svg" style="height:4.5vh;min-height:24px"></a>
+        <a href=""><img src="pics/smfidalgo_logo.svg" style="height:4.5vh;min-height:24px"></a>
         <div style="display:flex; align-items:center;">
           <div id="clockDot" style="width:6px; height:6px; background:#000; border-radius:50%; margin-right:6px;"></div>
           <div id="clock"></div>
@@ -49,24 +49,24 @@
       <p>If you are here for different reasons than learning more about me, write to
         <a href="mailto:serfidalgo@outlook.com" target="_blank" class="preview-link type-2 no-preview"
           style="opacity: 1" data-tooltip-title="Sergio's Email" data-tooltip-text="Drop me a line and let's talk"
-          data-tooltip-time="" data-tooltip-img="images/media/email.png">
+          data-tooltip-time="" data-tooltip-img="pics/email.png">
           serfidalgo@outlook.com
         </a>
       <p style="margin-top:1.8vh;">If you are still not satisfied, find me on these channels</br>
       <div class="socialIcons">
         <a href="https://www.linkedin.com/in/smfidalgo/" target="_blank" class="preview-link type-2 no-preview"
           data-tooltip-title="Sergio's LinkedIn" data-tooltip-text="A traditional view of my professional life"
-          data-tooltip-time="" data-tooltip-img="images/media/sergio.png">
+          data-tooltip-time="" data-tooltip-img="pics/sergio.png">
           LinkedIn
         </a>
         <a href="https://www.dribbble/smfidalgo" target="_blank" class="preview-link type-2 no-preview"
           data-tooltip-title="Sergio's Dribbble" data-tooltip-text="Some pieces of visual work here"
-          data-tooltip-time="" data-tooltip-img="images/media/logo-smf.png">
+          data-tooltip-time="" data-tooltip-img="pics/logo-smf.png">
           Dribbble
         </a>
         <a href="https://www.vimeo.com/smfidalgo" target="_blank" class="preview-link type-2 no-preview"
           data-tooltip-title="Sergio's Vimeo" data-tooltip-text="I also had fun using DSLR cameras!"
-          data-tooltip-time="" data-tooltip-img="images/media/vimeo.png">
+          data-tooltip-time="" data-tooltip-img="pics/vimeo.png">
           Vimeo
         </a>
       </div>
@@ -79,7 +79,7 @@
   <!-- ABOUT SCREEN -->
   <div id="aboutContent" class="screenContent">
     <div class="headerTop-inner">
-      <img src="images/smfidalgo_logo_white.svg" onclick="backToHome()" style="height:4.5vh;min-height:24px;cursor: pointer;">
+      <img src="pics/smfidalgo_logo_white.svg" onclick="backToHome()" style="height:4.5vh;min-height:24px;cursor: pointer;">
       <a class="" href="#" onclick="backToHome()" style="color:white; font-size: 1.8vh;text-decoration: none;">Back</a>
     </div>
 
@@ -92,19 +92,19 @@
       <div style="width:70%; line-height:1.5;">
         <p>I was born in Oviedo, Asturias, some people may call this place a natural paradise in <a
             href="https://en.wikipedia.org/wiki/Asturias" target="_blank" class="preview-link"
-            data-sources="images/media/asturias-1.jpg, images/media/asturias-4.jpg, images/media/asturias-6.jpg, images/media/asturias-2.jpg, images/media/asturias-3.jpg, images/media/asturias-5.jpg, images/media/asturias-7.jpg, images/media/asturias-8.jpg">
+            data-sources="pics/asturias-1.jpg, pics/asturias-4.jpg, pics/asturias-6.jpg, pics/asturias-2.jpg, pics/asturias-3.jpg, pics/asturias-5.jpg, pics/asturias-7.jpg, pics/asturias-8.jpg">
             Spain ↗</a>
         </p>
         <p>Ever since I was a kid I played musical instruments, thrived in orchestras and taught music.
         </p>
         <p>As I grew up I studied art and then took a specialization in <a href="https://dribbble.com/smfidalgo"
             target="_blank" class="preview-link"
-            data-sources="images/media/design-1.jpg,images/media/design-2.jpg, images/media/design-3.jpg, images/media/design-4.jpg, images/media/design-5.jpg, images/media/design-7.jpg, images/media/design-9.jpg, images/media/design-10.jpg,images/media/design-14.jpg, images/media/design-12.jpg, images/media/design-13.jpg">
+            data-sources="pics/design-1.jpg,pics/design-2.jpg, pics/design-3.jpg, pics/design-4.jpg, pics/design-5.jpg, pics/design-7.jpg, pics/design-9.jpg, pics/design-10.jpg,pics/design-14.jpg, pics/design-12.jpg, pics/design-13.jpg">
             advertising ↗</a></p>
         <p>Other than music and art I love everything related to food, or getting lost in new places. I often take time
           to enjoy the simple things that make life feel <a href="https://en.wikipedia.org/wiki/Asturias" target="_blank"
             class="preview-link"
-            data-sources="images/media/me-3.jpg, images/media/me-4.jpg, images/media/me-5.jpg, images/media/me-7.jpg, images/media/me-0.jpg, images/media/me-8.jpg, images/media/me-9.jpg, images/media/me-10.jpg, images/media/me-11.jpg, images/media/me-12.png">
+            data-sources="pics/me-3.jpg, pics/me-4.jpg, pics/me-5.jpg, pics/me-7.jpg, pics/me-0.jpg, pics/me-8.jpg, pics/me-9.jpg, pics/me-10.jpg, pics/me-11.jpg, pics/me-12.png">
             full ↗</a></p>
       </div>
     </div>
@@ -119,7 +119,7 @@
         <p>I love coding and getting lost in the technical aspects of building things.</p>
         <p>Today, I’m immersed in the world of data at
           <a href="https://www.collibra.com" target="_blank" class="preview-link type-2" data-tooltip-title="Collibra"
-            data-tooltip-text="Unified governance for data and AI" data-tooltip-time="" data-tooltip-img="images/media/collibra.png">
+            data-tooltip-text="Unified governance for data and AI" data-tooltip-time="" data-tooltip-img="pics/collibra.png">
             Collibra ↗
           </a>
 
@@ -134,22 +134,22 @@
       <div style="width:70%; line-height:0.5;">
         <p><a href="https://www.youtube.com/watch?v=hdp-WYvJSO4&t=1s" target="_blank" class="preview-link type-2"
             data-tooltip-title="Chema Madoz" data-tooltip-text="Poetry made photography" data-tooltip-time=""
-            data-tooltip-img="images/media/chema.png">
+            data-tooltip-img="pics/chema.png">
             Chema Madoz ↗
           </a>
           </br><a href="https://sagmeister.com/work/beautification/" target="_blank" class="preview-link type-2"
             data-tooltip-title="Stefan Segmeister" data-tooltip-text="Casual views on typography and beauty"
-            data-tooltip-time="" data-tooltip-img="images/media/stefan.png">
+            data-tooltip-time="" data-tooltip-img="pics/stefan.png">
             Stefan Segmeister ↗
           </a>
           </br><a href="https://en.wikipedia.org/wiki/Edward_Bernays"
           target=" _blank" class="preview-link type-2" data-tooltip-title="Edward Bernays"
-                data-tooltip-text="Know the past to understand the present" data-tooltip-time="" data-tooltip-img="images/media/edward.png">
+                data-tooltip-text="Know the past to understand the present" data-tooltip-time="" data-tooltip-img="pics/edward.png">
                 Edward Bernays ↗
               </a>
           </br><a href="https://open.spotify.com/artist/0epOFNiUfyON9EYx7Tpr6V" target="_blank" class="preview-link type-2"
             data-tooltip-title="The Strokes" data-tooltip-text="A soundtrack for the important things"
-            data-tooltip-time="" data-tooltip-img="images/media/the-strokes.png">
+            data-tooltip-time="" data-tooltip-img="pics/the-strokes.png">
             The Strokes ↗
           </a>
         </p>
@@ -164,24 +164,24 @@
       <p>If you are here for different reasons than learning more about me, write to
         <a href="mailto:serfidalgo@outlook.com" target="_blank" class="preview-link type-2 no-preview"
           style="opacity: 1" data-tooltip-title="Sergio's Email" data-tooltip-text="Drop me a line and let's talk"
-          data-tooltip-time="" data-tooltip-img="images/media/email.png">
+          data-tooltip-time="" data-tooltip-img="pics/email.png">
           serfidalgo@outlook.com
         </a>
       <p style="margin-top:1.8vh;">If you are still not satisfied, find me on these channels</br>
       <div class="socialIcons">
         <a href="https://www.linkedin.com/in/smfidalgo/" target="_blank" class="preview-link type-2 no-preview"
           data-tooltip-title="Sergio's LinkedIn" data-tooltip-text="A traditional view of my professional life"
-          data-tooltip-time="" data-tooltip-img="images/media/sergio.png">
+          data-tooltip-time="" data-tooltip-img="pics/sergio.png">
           LinkedIn
         </a>
         <a href="https://www.dribbble/smfidalgo" target="_blank" class="preview-link type-2 no-preview"
           data-tooltip-title="Sergio's Dribbble" data-tooltip-text="Some pieces of visual work here"
-          data-tooltip-time="" data-tooltip-img="images/media/logo-smf.png">
+          data-tooltip-time="" data-tooltip-img="pics/logo-smf.png">
           Dribbble
         </a>
         <a href="https://www.vimeo.com/smfidalgo" target="_blank" class="preview-link type-2 no-preview"
           data-tooltip-title="Sergio's Vimeo" data-tooltip-text="I also had fun using DSLR cameras!"
-          data-tooltip-time="" data-tooltip-img="images/media/vimeo.png">
+          data-tooltip-time="" data-tooltip-img="pics/vimeo.png">
           Vimeo
         </a>
       </div>
@@ -195,7 +195,7 @@
   <!-- WORK SCREEN -->
   <div id="workContent" class="screenContent">
     <div class="headerTop-inner">
-      <img src="images/smfidalgo_logo_white.svg" onclick="backToHome()" style="height:4.5vh;min-height:24px;cursor: pointer;">
+      <img src="pics/smfidalgo_logo_white.svg" onclick="backToHome()" style="height:4.5vh;min-height:24px;cursor: pointer;">
       <a class="" href="#" onclick="backToHome()" style="color:white; font-size: 1.8vh;text-decoration: none;">Back</a>
     </div>
 
@@ -217,7 +217,7 @@
         <p>From 2022 I worked closely with the core team at Nasdaq Private Market, helping them successfully close their
           <a href="https://www.nasdaqprivatemarket.com/nasdaq-private-market-closes-62-4-million-series-b-financing-led-by-nasdaq-with-new-investments-from-bnp-paribas-drw-venture-capital-ubs-and-wells-fargo/"
             target="_blank" class="preview-link"
-            data-sources="images/media/npm-0.mp4, images/media/npm-1.png, images/media/npm-2.mp4, images/media/npm-4.png">
+            data-sources="pics/npm-0.mp4, pics/npm-1.png, pics/npm-2.mp4, pics/npm-4.png">
             Series B ↗</a>
         <p>At NPM I led the design team while contributed to the execution efforts, from setting up the overall design infrastructure to executing on zero-to-one initiatives, or iterating solutions through data and customer feedback. </p>
       </div>
@@ -228,7 +228,7 @@
       <div style="width:70%; line-height:1.5;">
         <p>At <a href="https://dribbble.com/smfidalgo"
           target="_blank" class="preview-link"
-          data-sources="images/media/product-1.mp4, images/media/product-3.png, images/media/product-2.mp4, images/media/product-4.mp4, images/media/product-5.png, images/media/product-6.png, images/media/product-7.png, images/media/product-8.png, images/media/product-9.png, images/media/product-10.png, images/media/product-11.mp4, images/media/product-12.jpg, images/media/product-13.png, images/media/product-14.png">
+          data-sources="pics/product-1.mp4, pics/product-3.png, pics/product-2.mp4, pics/product-4.mp4, pics/product-5.png, pics/product-6.png, pics/product-7.png, pics/product-8.png, pics/product-9.png, pics/product-10.png, pics/product-11.mp4, pics/product-12.jpg, pics/product-13.png, pics/product-14.png">
           agencies ↗</a> I worked with a number of teams and clients
           of different sizes, which allowed me to stay curious about diverse industries, business models and customer segments.</p>
       </div>
@@ -241,22 +241,22 @@
       <div style="width:70%; line-height:0.5;">
         <p><a href="https://en.wikipedia.org/wiki/Don_Norman" target="_blank" class="preview-link type-2"
             data-tooltip-title="Don Norman" data-tooltip-text="A look at everyday things" data-tooltip-time=""
-            data-tooltip-img="images/media/norman.jpg">
+            data-tooltip-img="pics/norman.jpg">
             Don Norman ↗
           </a>
           </br><a href="https://www.svpg.com/team/marty-cagan/" target="_blank" class="preview-link type-2"
             data-tooltip-title="Marty Cagan" data-tooltip-text="Frameworks to think, work, and win"
-            data-tooltip-time="" data-tooltip-img="images/media/marty.png">
+            data-tooltip-time="" data-tooltip-img="pics/marty.png">
             Marty Cagan ↗
           </a>
           </br><a href="https://bradfrost.com/"
           target=" _blank" class="preview-link type-2" data-tooltip-title="Brad Frost"
-                data-tooltip-text="Physics applied to art (Atomic design)" data-tooltip-time="" data-tooltip-img="images/media/brad.png">
+                data-tooltip-text="Physics applied to art (Atomic design)" data-tooltip-time="" data-tooltip-img="pics/brad.png">
                 Brad Frost ↗
               </a>
           </br><a href="https://www.instagram.com/erik.winkowski/" target="_blank" class="preview-link type-2"
             data-tooltip-title="Erik Winkowski" data-tooltip-text="Even these days one can be original!"
-            data-tooltip-time="" data-tooltip-img="images/media/erik.png">
+            data-tooltip-time="" data-tooltip-img="pics/erik.png">
             Erik Winkowski ↗
           </a>
         </p>
@@ -271,24 +271,24 @@
       <p>If you are here for different reasons than learning more about me, write to
         <a href="mailto:serfidalgo@outlook.com" target="_blank" class="preview-link type-2 no-preview"
           style="opacity: 1" data-tooltip-title="Sergio's Email" data-tooltip-text="Drop me a line and let's talk"
-          data-tooltip-time="" data-tooltip-img="images/media/email.png">
+          data-tooltip-time="" data-tooltip-img="pics/email.png">
           serfidalgo@outlook.com
         </a>
       <p style="margin-top:1.8vh;">If you are still not satisfied, find me on these channels</br>
       <div class="socialIcons">
         <a href="https://www.linkedin.com/in/smfidalgo/" target="_blank" class="preview-link type-2 no-preview"
           data-tooltip-title="Sergio's LinkedIn" data-tooltip-text="A traditional view of my professional life"
-          data-tooltip-time="" data-tooltip-img="images/media/sergio.png">
+          data-tooltip-time="" data-tooltip-img="pics/sergio.png">
           LinkedIn
         </a>
         <a href="https://www.dribbble/smfidalgo" target="_blank" class="preview-link type-2 no-preview"
           data-tooltip-title="Sergio's Dribbble" data-tooltip-text="Some pieces of visual work here"
-          data-tooltip-time="" data-tooltip-img="images/media/logo-smf.png">
+          data-tooltip-time="" data-tooltip-img="pics/logo-smf.png">
           Dribbble
         </a>
         <a href="https://www.vimeo.com/smfidalgo" target="_blank" class="preview-link type-2 no-preview"
           data-tooltip-title="Sergio's Vimeo" data-tooltip-text="I also had fun using DSLR cameras!"
-          data-tooltip-time="" data-tooltip-img="images/media/vimeo.png">
+          data-tooltip-time="" data-tooltip-img="pics/vimeo.png">
           Vimeo
         </a>
       </div>


### PR DESCRIPTION
This commit corrects the project structure and media file handling:

- All images, videos, and SVG assets are now sourced from a single `pics/` directory at the root of the project.
- All paths in `wp-site.html` and `js/main.js` have been updated to correctly reference files within the `pics/` directory (e.g., `pics/filename.ext`).
- Inline CSS and JavaScript were previously moved to `css/styles.css` and `js/main.js` respectively.
- Obsolete image directories (`images/`, `images/media/`) have been confirmed to be removed or not present.

This ensures the micro-site uses a cleaner, more standard project taxonomy with all media assets properly organized and referenced.