### PR TITLE
Fix: Inner pages not visible after preloader implementation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -140,29 +140,67 @@ handImg.src = selectedHand.home;
 
     // --- NAVIGATION ---
     function openAbout() {
-      if (homeContentEl) homeContentEl.style.display = 'none';
-      if (workContentEl) workContentEl.style.display = 'none';
+      if (homeContentEl) {
+        homeContentEl.style.display = 'none';
+        homeContentEl.style.opacity = '0';
+        homeContentEl.style.visibility = 'hidden';
+      }
+      if (workContentEl) {
+        workContentEl.style.display = 'none';
+        workContentEl.style.opacity = '0';
+        workContentEl.style.visibility = 'hidden';
+      }
       if (aboutContentEl) {
         aboutContentEl.style.display = 'block';
+        // Trigger reflow before changing opacity for transition
+        aboutContentEl.offsetHeight; // NOSONAR: This is a deliberate reflow trigger
+        aboutContentEl.style.opacity = '1';
+        aboutContentEl.style.visibility = 'visible';
         aboutContentEl.scrollTop = 0;
       }
       if (handImg && selectedHand) handImg.src = selectedHand.about;
     }
 
     function openWork() {
-      if (homeContentEl) homeContentEl.style.display = 'none';
-      if (aboutContentEl) aboutContentEl.style.display = 'none';
+      if (homeContentEl) {
+        homeContentEl.style.display = 'none';
+        homeContentEl.style.opacity = '0';
+        homeContentEl.style.visibility = 'hidden';
+      }
+      if (aboutContentEl) {
+        aboutContentEl.style.display = 'none';
+        aboutContentEl.style.opacity = '0';
+        aboutContentEl.style.visibility = 'hidden';
+      }
       if (workContentEl) {
         workContentEl.style.display = 'block';
+        // Trigger reflow before changing opacity for transition
+        workContentEl.offsetHeight; // NOSONAR: This is a deliberate reflow trigger
+        workContentEl.style.opacity = '1';
+        workContentEl.style.visibility = 'visible';
         workContentEl.scrollTop = 0;
       }
       if (handImg && selectedHand) handImg.src = selectedHand.about;
     }
 
     function backToHome() {
-      if (aboutContentEl) aboutContentEl.style.display = 'none';
-      if (workContentEl) workContentEl.style.display = 'none';
-      if (homeContentEl) homeContentEl.style.display = 'flex';
+      if (aboutContentEl) {
+        aboutContentEl.style.display = 'none';
+        aboutContentEl.style.opacity = '0';
+        aboutContentEl.style.visibility = 'hidden';
+      }
+      if (workContentEl) {
+        workContentEl.style.display = 'none';
+        workContentEl.style.opacity = '0';
+        workContentEl.style.visibility = 'hidden';
+      }
+      if (homeContentEl) {
+        homeContentEl.style.display = 'flex';
+        // Trigger reflow before changing opacity for transition
+        homeContentEl.offsetHeight; // NOSONAR: This is a deliberate reflow trigger
+        homeContentEl.style.opacity = '1';
+        homeContentEl.style.visibility = 'visible';
+      }
       if (handImg && selectedHand) handImg.src = selectedHand.home;
     }
 


### PR DESCRIPTION
This commit resolves a regression where the "Who is Sergio" (aboutContent) and "What do I do" (workContent) pages were not becoming visible after the FOUC/preloader enhancements.

The navigation functions (`openAbout`, `openWork`, `backToHome`) in `js/main.js` have been updated to correctly manage the `opacity` and `visibility` styles in addition to the `display` style for the content sections.

When a section is navigated to, its `display` property is set appropriately (`block` or `flex`), a reflow is triggered, and then `opacity` is set to `1` and `visibility` to `visible`, allowing it to fade in using existing CSS transitions. Sections being navigated away from have their `display` set to `none` and opacity/visibility set to hidden states.

This ensures that the preloader hides content initially, and subsequent navigation correctly reveals the selected inner page.